### PR TITLE
Support EntityFramework with YugabyteDB Smart driver

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -50,8 +50,8 @@
     <Using Include="Microsoft.EntityFrameworkCore.Utilities" />
     <Using Include="Microsoft.Extensions.Logging" />
     <Using Include="Microsoft.Extensions.DependencyInjection" />
-    <Using Include="Npgsql" />
-    <Using Include="NpgsqlTypes" />
+    <Using Include="YBNpgsql" />
+    <Using Include="YBNpgsqlTypes" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <EFCoreVersion>8.0.4</EFCoreVersion>
     <MicrosoftExtensionsVersion>8.0.0</MicrosoftExtensionsVersion>
-    <NpgsqlVersion>8.0.3</NpgsqlVersion>
+    <NpgsqlVersion>8.0.3-yb-1</NpgsqlVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,7 +16,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
 
-    <PackageVersion Include="Npgsql" Version="$(NpgsqlVersion)" />
+    <PackageVersion Include="NpgsqlYugabyteDB" Version="$(NpgsqlVersion)" />
     <PackageVersion Include="Npgsql.NodaTime" Version="$(NpgsqlVersion)" />
     <PackageVersion Include="Npgsql.NetTopologySuite" Version="$(NpgsqlVersion)" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="$(NpgsqlVersion)" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -13,6 +13,8 @@
         <packageSource key="nuget.org">
             <package pattern="*" />
             <!-- Our npgsql-vnext feed doesn't necessarily contain the last preview (package retention rules...), so we take it from nuget.org -->
+            <package pattern="YBNpgsql" />
+            <package pattern="YBNpgsql.*" />
             <package pattern="Npgsql" />
             <package pattern="Npgsql.*" />
         </packageSource>

--- a/src/EFCore.PG/Design/Internal/NpgsqlCSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore.PG/Design/Internal/NpgsqlCSharpRuntimeAnnotationCodeGenerator.cs
@@ -67,7 +67,7 @@ public class NpgsqlCSharpRuntimeAnnotationCodeGenerator : RelationalCSharpRuntim
                     $"{parameters.TargetName}.TypeMapping = (({typeMapping.GetType().Name}){parameters.TargetName}.TypeMapping).Clone(npgsqlDbType: ");
 
                 mainBuilder
-                    .Append(nameof(NpgsqlTypes))
+                    .Append(nameof(YBNpgsqlTypes))
                     .Append(".")
                     .Append(nameof(NpgsqlDbType))
                     .Append(".")
@@ -109,7 +109,7 @@ public class NpgsqlCSharpRuntimeAnnotationCodeGenerator : RelationalCSharpRuntim
 
                     mainBuilder
                         .Append("npgsqlDbType: ")
-                        .Append(nameof(NpgsqlTypes))
+                        .Append(nameof(YBNpgsqlTypes))
                         .Append(".")
                         .Append(nameof(NpgsqlDbType))
                         .Append(".")

--- a/src/EFCore.PG/EFCore.PG.csproj
+++ b/src/EFCore.PG/EFCore.PG.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" PrivateAssets="none" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" PrivateAssets="none" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" PrivateAssets="none" />
-    <PackageReference Include="Npgsql" />
+    <PackageReference Include="NpgsqlYugabyteDB" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EFCore.PG/Extensions/BuilderExtensions/NpgsqlModelBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/BuilderExtensions/NpgsqlModelBuilderExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
-using Npgsql.NameTranslation;
+using YBNpgsql.NameTranslation;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore;

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlArrayTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlArrayTypeMapping.cs
@@ -186,7 +186,7 @@ public class NpgsqlArrayTypeMapping<TCollection, TConcreteCollection, TElement> 
         // If the element mapping has an NpgsqlDbType or DbType, set our own NpgsqlDbType as an array of that.
         // Otherwise let the ADO.NET layer infer the PostgreSQL type. We can't always let it infer, otherwise
         // when given a byte[] it will infer byte (but we want smallint[])
-        NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Array
+        NpgsqlDbType = YBNpgsqlTypes.NpgsqlDbType.Array
             | (ElementTypeMapping is INpgsqlTypeMapping elementNpgsqlTypeMapping
                 ? elementNpgsqlTypeMapping.NpgsqlDbType
                 : ElementTypeMapping.DbType.HasValue

--- a/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
@@ -11,7 +11,7 @@ using System.Text;
 using System.Text.Json;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping;
-using Npgsql.Internal;
+using YBNpgsql.Internal;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal;
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -16,7 +16,7 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="GitHubActionsTestLogger" />
-    <PackageReference Include="Npgsql" />
+    <PackageReference Include="NpgsqlYugabyteDB" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore.Storage.Json;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping;
-using Npgsql.NameTranslation;
+using YBNpgsql.NameTranslation;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage;
 


### PR DESCRIPTION
Problem:
Entity Framework is currently not supported with the C# smart driver because of namespace change from Npgsql to YBNpgsql, and the upstream postgres adapter implicitly references the upstream driver.

Changes made:
- Changed the references of the upstream driver to YugabyteDB Smart driver
- Changed the namespace from Npgsql-> YBNpgsql
- Changed the namespace from NpgsqlTypes-> YBNpgsqlTypes

Tests Done:
Wrote a sample entity framework app and verified it with `Load Balance Hosts` and `Topology Keys` specified using the locally published upgraded driver